### PR TITLE
Update some parameters based on hardware testing

### DIFF
--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -27,8 +27,8 @@
   <arg name="contact_check_lvs_distance" default="0.05"/>
   <arg name="ompl_max_planning_time" default="5.0"/>
   <arg name="tcp_max_speed" default="0.4"/>
-  <arg name="cartesian_tolerance" default="[0.01, 0.01, 0.01, 0.05, 0.05, 6.28]"/>
-  <arg name="cartesian_coefficient" default="[2.5, 2.5, 2.5, 2.5, 2.5, 0.0]"/>
+  <arg name="cartesian_tolerance" default="[0.01, 0.01, 0.01, 0.05, 0.05, 0.05]"/>
+  <arg name="cartesian_coefficient" default="[2.5, 2.5, 2.5, 2.5, 2.5, 2.5]"/>
 
   <node pkg="snp_motion_planning" exec="snp_motion_planning_node" output="screen">
     <!-- General -->

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -18,9 +18,9 @@
   <!-- Profiles -->
   <arg name="velocity_scaling_factor" default="1.0"/>
   <arg name="acceleration_scaling_factor" default="1.0"/>
-  <arg name="max_translational_vel" default="0.150"/>
+  <arg name="max_translational_vel" default="0.10"/>
   <arg name="max_rotational_vel" default="1.571"/>
-  <arg name="max_translational_acc" default="0.3"/>
+  <arg name="max_translational_acc" default="0.2"/>
   <arg name="max_rotational_acc" default="3.14"/>
   <arg name="check_joint_accelerations" default="false"/>
   <arg name="min_contact_distance" default="0.0"/>


### PR DESCRIPTION
## Description
This MR merges some parameter changes after testing the inspection toolpaths on the real robot. 

Note: this MR depends on #1 .

## Changes
- Dynamics were made a bit slower to work safely with the real robot. acceleration is reduced to prevent jerky motion in between transitions for the rasters.
- Constraints were added on the z-axis because for SNP this constraint doesn't matter, but it matters when using an assymetric tool like the NDT rollerprobe sensor. 
- `cartesian_tolerance` is reduced so that the end effector doesn't have too much space to rotate in z-axis. A `cartesian_cost` was added for the z-axis so planning respects this as a constraint.