### PR TITLE
Add Custom ifopt profiles

### DIFF
--- a/snp_motion_planning/CMakeLists.txt
+++ b/snp_motion_planning/CMakeLists.txt
@@ -47,6 +47,8 @@ target_link_libraries(
   tesseract::tesseract_time_parameterization_core
   tesseract::tesseract_environment
   tesseract::tesseract_motion_planners_core
+  trajopt::trajopt_ifopt
+  trajopt::trajopt_sqp
   yaml-cpp)
 
 # Planning server
@@ -67,6 +69,7 @@ target_link_libraries(
   tesseract::tesseract_motion_planners_descartes
   tesseract::tesseract_time_parameterization_isp
   tesseract::tesseract_kinematics_kdl
+  trajopt::trajopt_ifopt
   yaml-cpp)
 
 # Plugin Library

--- a/snp_motion_planning/CMakeLists.txt
+++ b/snp_motion_planning/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(
   src/plugins/tasks/kinematic_limits_check_profile.cpp
   src/plugins/tasks/kinematic_limits_check_task.cpp
   src/plugins/tasks/tcp_speed_limiter_profile.cpp
-  src/plugins/tasks/tcp_speed_limiter_task.cpp)
+  src/plugins/tasks/tcp_speed_limiter_task.cpp
+  src/trajopt_custom_composite_profile.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_tasks
   tesseract::tesseract_common
@@ -49,6 +50,7 @@ target_link_libraries(
   tesseract::tesseract_motion_planners_core
   trajopt::trajopt_ifopt
   trajopt::trajopt_sqp
+  trajopt::trajopt 
   yaml-cpp)
 
 # Planning server
@@ -69,6 +71,7 @@ target_link_libraries(
   tesseract::tesseract_motion_planners_descartes
   tesseract::tesseract_time_parameterization_isp
   tesseract::tesseract_kinematics_kdl
+  tesseract::tesseract_motion_planners_trajopt
   trajopt::trajopt_ifopt
   yaml-cpp)
 

--- a/snp_motion_planning/CMakeLists.txt
+++ b/snp_motion_planning/CMakeLists.txt
@@ -73,7 +73,6 @@ target_link_libraries(
   tesseract::tesseract_motion_planners_descartes
   tesseract::tesseract_time_parameterization_isp
   tesseract::tesseract_kinematics_kdl
-  tesseract::tesseract_motion_planners_trajopt
   trajopt::trajopt_ifopt
   yaml-cpp)
 

--- a/snp_motion_planning/CMakeLists.txt
+++ b/snp_motion_planning/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(
   tesseract::tesseract_environment
   tesseract::tesseract_motion_planners_core
   trajopt::trajopt_ifopt
+  tesseract::tesseract_motion_planners_trajopt_ifopt
   trajopt::trajopt_sqp
   trajopt::trajopt 
   yaml-cpp)
@@ -68,6 +69,7 @@ target_link_libraries(
   tesseract::tesseract_motion_planners_simple
   tesseract::tesseract_motion_planners_ompl
   tesseract::tesseract_motion_planners_trajopt
+  tesseract::tesseract_motion_planners_trajopt_ifopt
   tesseract::tesseract_motion_planners_descartes
   tesseract::tesseract_time_parameterization_isp
   tesseract::tesseract_kinematics_kdl

--- a/snp_motion_planning/CMakeLists.txt
+++ b/snp_motion_planning/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(
   src/plugins/tasks/kinematic_limits_check_task.cpp
   src/plugins/tasks/tcp_speed_limiter_profile.cpp
   src/plugins/tasks/tcp_speed_limiter_task.cpp
-  src/trajopt_custom_composite_profile.cpp)
+  src/trajopt_ifopt_custom_composite_profile.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_tasks
   tesseract::tesseract_common

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -157,9 +157,9 @@ createTrajOptToolZFreePlanProfile(const Eigen::VectorXd& cart_tolerance = Eigen:
   return profile;
 }
 
-std::shared_ptr<tesseract_planning::TrajOptIfoptCustomCompositeProfile>
-createCustomTrajOptProfile(double min_contact_distance, const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
-                     double longest_valid_segment_length)
+std::shared_ptr<tesseract_planning::TrajOptIfoptCustomCompositeProfile> createCustomTrajOptProfile(
+    double min_contact_distance, const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
+    double longest_valid_segment_length)
 {
   // TrajOpt profiles
   auto profile = std::make_shared<tesseract_planning::TrajOptIfoptCustomCompositeProfile>();

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -8,12 +8,14 @@
 #include <tesseract_motion_planners/ompl/ompl_planner_configurator.h>
 #include <tesseract_motion_planners/ompl/profile/ompl_real_vector_plan_profile.h>
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h>
+#include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
 #include <tesseract_motion_planners/simple/profile/simple_planner_lvs_plan_profile.h>
 #include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
 
 #include "trajopt_ifopt_custom_composite_profile.h"
 
 static const std::string TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask";
+static const std::string TRAJOPT_CUSTOM_NAMESPACE = "CustomTrajOptMotionPlannerTask";
 static const std::string OMPL_DEFAULT_NAMESPACE = "OMPLMotionPlannerTask";
 static const std::string DESCARTES_DEFAULT_NAMESPACE = "DescartesMotionPlannerTask";
 static const std::string SIMPLE_DEFAULT_NAMESPACE = "SimpleMotionPlannerTask";
@@ -239,12 +241,12 @@ std::shared_ptr<tesseract_planning::TrajOptIfoptCustomCompositeProfile> createCu
   return profile;
 }
 
-std::shared_ptr<tesseract_planning::TrajOptIfoptCustomCompositeProfile>
+std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile>
 createTrajOptProfile(double min_contact_distance, const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
                      double longest_valid_segment_length)
 {
   // TrajOpt profiles
-  auto profile = std::make_shared<tesseract_planning::TrajOptIfoptCustomCompositeProfile>();
+  auto profile = std::make_shared<tesseract_planning::TrajOptDefaultCompositeProfile>();
   profile->smooth_velocities = false;
   profile->velocity_coeff = Eigen::VectorXd::Constant(1, 1, 10.0);
   profile->smooth_accelerations = true;

--- a/snp_motion_planning/src/planner_profiles.hpp
+++ b/snp_motion_planning/src/planner_profiles.hpp
@@ -8,11 +8,10 @@
 #include <tesseract_motion_planners/ompl/ompl_planner_configurator.h>
 #include <tesseract_motion_planners/ompl/profile/ompl_real_vector_plan_profile.h>
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h>
-#include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
-#include "trajopt_ifopt_custom_composite_profile.h"
-
 #include <tesseract_motion_planners/simple/profile/simple_planner_lvs_plan_profile.h>
 #include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
+
+#include "trajopt_ifopt_custom_composite_profile.h"
 
 static const std::string TRAJOPT_DEFAULT_NAMESPACE = "TrajOptMotionPlannerTask";
 static const std::string OMPL_DEFAULT_NAMESPACE = "OMPLMotionPlannerTask";
@@ -240,12 +239,12 @@ std::shared_ptr<tesseract_planning::TrajOptIfoptCustomCompositeProfile> createCu
   return profile;
 }
 
-std::shared_ptr<tesseract_planning::TrajOptDefaultCompositeProfile>
+std::shared_ptr<tesseract_planning::TrajOptIfoptCustomCompositeProfile>
 createTrajOptProfile(double min_contact_distance, const std::vector<ExplicitCollisionPair>& unique_collision_pairs,
                      double longest_valid_segment_length)
 {
   // TrajOpt profiles
-  auto profile = std::make_shared<tesseract_planning::TrajOptDefaultCompositeProfile>();
+  auto profile = std::make_shared<tesseract_planning::TrajOptIfoptCustomCompositeProfile>();
   profile->smooth_velocities = false;
   profile->velocity_coeff = Eigen::VectorXd::Constant(1, 1, 10.0);
   profile->smooth_accelerations = true;

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -495,14 +495,10 @@ private:
       // TrajOpt
       profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
                                createTrajOptToolZFreePlanProfile(cart_tolerance, cart_coeff));
-      // profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
-      //                          createTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
-  
 
-      profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
-                               createCustomTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
-
-      RCLCPP_INFO(node_->get_logger(), ":::::::::::::::::::::::::::::::::::::::Created custom trajopr profile");
+      profile_dict->addProfile(
+          TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
+          createCustomTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
 
       // Descartes
       profile_dict->addProfile(DESCARTES_DEFAULT_NAMESPACE, PROFILE,

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -495,8 +495,14 @@ private:
       // TrajOpt
       profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
                                createTrajOptToolZFreePlanProfile(cart_tolerance, cart_coeff));
+      // profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
+      //                          createTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
+  
+
       profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
-                               createTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
+                               createCustomTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
+
+      RCLCPP_INFO(node_->get_logger(), ":::::::::::::::::::::::::::::::::::::::Created custom trajopr profile");
 
       // Descartes
       profile_dict->addProfile(DESCARTES_DEFAULT_NAMESPACE, PROFILE,

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -496,8 +496,10 @@ private:
       profile_dict->addProfile(TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
                                createTrajOptToolZFreePlanProfile(cart_tolerance, cart_coeff));
 
+      // This uses the custom TrajOpt profile with IFOPT. The composer plugins should reference the
+      // TRAJOPT_CUSTOM_NAMESPACE to utilize this.
       profile_dict->addProfile(
-          TRAJOPT_DEFAULT_NAMESPACE, PROFILE,
+          TRAJOPT_CUSTOM_NAMESPACE, PROFILE,
           createCustomTrajOptProfile(min_contact_dist, collision_pairs, longest_valid_segment_length));
 
       // Descartes

--- a/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
+++ b/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/shared_ptr.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_motion_planners/trajopt/profile/trajopt_custom_composite_profile.h>
+#include "trajopt_ifopt_custom_composite_profile.h"
 #include <tesseract_motion_planners/trajopt/trajopt_utils.h>
 #include <tesseract_motion_planners/core/utils.h>
 
@@ -53,7 +53,7 @@ static const double LONGEST_VALID_SEGMENT_FRACTION_DEFAULT = 0.01;
 namespace tesseract_planning
 {
 TrajOptTermInfos
-TrajOptCustomCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
+TrajOptIfoptCustomCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
                                        const std::shared_ptr<const tesseract_environment::Environment>& env,
                                        const std::vector<int>& fixed_indices,
                                        int start_index,
@@ -153,7 +153,7 @@ TrajOptCustomCompositeProfile::create(const tesseract_common::ManipulatorInfo& c
   return term_infos;
 }
 
-double TrajOptCustomCompositeProfile::computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const
+double TrajOptIfoptCustomCompositeProfile::computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const
 {
   // Calculate longest valid segment length
   double extent = (joint_limits.col(1) - joint_limits.col(0)).norm();
@@ -170,7 +170,7 @@ double TrajOptCustomCompositeProfile::computeLongestValidSegmentLength(const Eig
 }
 
 template <class Archive>
-void TrajOptCustomCompositeProfile::serialize(Archive& ar, const unsigned int /*version*/)
+void TrajOptIfoptCustomCompositeProfile::serialize(Archive& ar, const unsigned int /*version*/)
 {
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TrajOptCompositeProfile);
   ar& BOOST_SERIALIZATION_NVP(contact_test_type);
@@ -193,5 +193,5 @@ void TrajOptCustomCompositeProfile::serialize(Archive& ar, const unsigned int /*
 }  // namespace tesseract_planning
 
 #include <tesseract_common/serialization.h>
-TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptCustomCompositeProfile)
-BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptCustomCompositeProfile)
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptIfoptCustomCompositeProfile)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptIfoptCustomCompositeProfile)

--- a/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
+++ b/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
@@ -54,10 +54,8 @@ namespace tesseract_planning
 {
 TrajOptTermInfos
 TrajOptIfoptCustomCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
-                                       const std::shared_ptr<const tesseract_environment::Environment>& env,
-                                       const std::vector<int>& fixed_indices,
-                                       int start_index,
-                                       int end_index) const
+                                           const std::shared_ptr<const tesseract_environment::Environment>& env,
+                                           const std::vector<int>& fixed_indices, int start_index, int end_index) const
 {
   // -------- Construct the problem ------------
   // -------------------------------------------
@@ -69,16 +67,11 @@ TrajOptIfoptCustomCompositeProfile::create(const tesseract_common::ManipulatorIn
 
   if (collision_constraint_config.enabled)
   {
-    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(start_index,
-                                                        end_index,
-                                                        collision_constraint_config.safety_margin,
-                                                        collision_constraint_config.safety_margin_buffer,
-                                                        collision_constraint_config.type,
-                                                        collision_constraint_config.use_weighted_sum,
-                                                        collision_constraint_config.coeff,
-                                                        contact_test_type,
-                                                        lvs_length,
-                                                        trajopt::TermType::TT_CNT);
+    trajopt::TermInfo::Ptr ti =
+        createCollisionTermInfo(start_index, end_index, collision_constraint_config.safety_margin,
+                                collision_constraint_config.safety_margin_buffer, collision_constraint_config.type,
+                                collision_constraint_config.use_weighted_sum, collision_constraint_config.coeff,
+                                contact_test_type, lvs_length, trajopt::TermType::TT_CNT);
 
     // Update the term info with the (possibly) new start and end state indices for which to apply this cost
     std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
@@ -97,16 +90,10 @@ TrajOptIfoptCustomCompositeProfile::create(const tesseract_common::ManipulatorIn
   if (collision_cost_config.enabled)
   {
     // Create a default collision term info
-    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(start_index,
-                                                        end_index,
-                                                        collision_cost_config.safety_margin,
-                                                        collision_cost_config.safety_margin_buffer,
-                                                        collision_cost_config.type,
-                                                        collision_cost_config.use_weighted_sum,
-                                                        collision_cost_config.coeff,
-                                                        contact_test_type,
-                                                        lvs_length,
-                                                        trajopt::TermType::TT_COST);
+    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
+        start_index, end_index, collision_cost_config.safety_margin, collision_cost_config.safety_margin_buffer,
+        collision_cost_config.type, collision_cost_config.use_weighted_sum, collision_cost_config.coeff,
+        contact_test_type, lvs_length, trajopt::TermType::TT_COST);
 
     // Update the term info with the (possibly) new start and end state indices for which to apply this cost
     std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
@@ -147,8 +134,8 @@ TrajOptIfoptCustomCompositeProfile::create(const tesseract_common::ManipulatorIn
   }
 
   if (avoid_singularity)
-    term_infos.costs.push_back(createAvoidSingularityTermInfo(
-        start_index, end_index, composite_manip_info.tcp_frame, avoid_singularity_coeff));
+    term_infos.costs.push_back(createAvoidSingularityTermInfo(start_index, end_index, composite_manip_info.tcp_frame,
+                                                              avoid_singularity_coeff));
 
   return term_infos;
 }

--- a/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
+++ b/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
@@ -1,0 +1,197 @@
+/**
+ * @file trajopt_custom_composite_profile.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @date June 18, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <trajopt/problem_description.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_motion_planners/trajopt/profile/trajopt_custom_composite_profile.h>
+#include <tesseract_motion_planners/trajopt/trajopt_utils.h>
+#include <tesseract_motion_planners/core/utils.h>
+
+#include <tesseract_command_language/poly/instruction_poly.h>
+#include <tesseract_command_language/poly/move_instruction_poly.h>
+#include <tesseract_command_language/cartesian_waypoint.h>
+#include <tesseract_command_language/joint_waypoint.h>
+
+#include <tesseract_common/eigen_serialization.h>
+#include <tesseract_common/manipulator_info.h>
+#include <tesseract_kinematics/core/joint_group.h>
+#include <tesseract_environment/environment.h>
+#include <trajopt_common/utils.hpp>
+
+static const double LONGEST_VALID_SEGMENT_FRACTION_DEFAULT = 0.01;
+
+namespace tesseract_planning
+{
+TrajOptTermInfos
+TrajOptCustomCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
+                                       const std::shared_ptr<const tesseract_environment::Environment>& env,
+                                       const std::vector<int>& fixed_indices,
+                                       int start_index,
+                                       int end_index) const
+{
+  // -------- Construct the problem ------------
+  // -------------------------------------------
+  TrajOptTermInfos term_infos;
+  tesseract_kinematics::JointGroup::ConstPtr joint_group = env->getJointGroup(composite_manip_info.manipulator);
+  const Eigen::Index dof = joint_group->numJoints();
+  const Eigen::MatrixX2d joint_limits = joint_group->getLimits().joint_limits;
+  const double lvs_length = computeLongestValidSegmentLength(joint_limits);
+
+  if (collision_constraint_config.enabled)
+  {
+    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(start_index,
+                                                        end_index,
+                                                        collision_constraint_config.safety_margin,
+                                                        collision_constraint_config.safety_margin_buffer,
+                                                        collision_constraint_config.type,
+                                                        collision_constraint_config.use_weighted_sum,
+                                                        collision_constraint_config.coeff,
+                                                        contact_test_type,
+                                                        lvs_length,
+                                                        trajopt::TermType::TT_CNT);
+
+    // Update the term info with the (possibly) new start and end state indices for which to apply this cost
+    std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
+    if (special_collision_constraint)
+    {
+      for (auto& info : ct->info)
+      {
+        info = special_collision_constraint;
+      }
+    }
+    ct->fixed_steps = fixed_indices;
+
+    term_infos.constraints.push_back(ct);
+  }
+
+  if (collision_cost_config.enabled)
+  {
+    // Create a default collision term info
+    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(start_index,
+                                                        end_index,
+                                                        collision_cost_config.safety_margin,
+                                                        collision_cost_config.safety_margin_buffer,
+                                                        collision_cost_config.type,
+                                                        collision_cost_config.use_weighted_sum,
+                                                        collision_cost_config.coeff,
+                                                        contact_test_type,
+                                                        lvs_length,
+                                                        trajopt::TermType::TT_COST);
+
+    // Update the term info with the (possibly) new start and end state indices for which to apply this cost
+    std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
+    if (special_collision_cost)
+    {
+      for (auto& info : ct->info)
+      {
+        info = special_collision_cost;
+      }
+    }
+    ct->fixed_steps = fixed_indices;
+
+    term_infos.costs.push_back(ct);
+  }
+
+  if (smooth_velocities)
+  {
+    if (velocity_coeff.size() == 0)
+      term_infos.costs.push_back(createSmoothVelocityTermInfo(start_index, end_index, static_cast<int>(dof)));
+    else
+      term_infos.costs.push_back(createSmoothVelocityTermInfo(start_index, end_index, velocity_coeff));
+  }
+
+  if (smooth_accelerations)
+  {
+    if (acceleration_coeff.size() == 0)
+      term_infos.costs.push_back(createSmoothAccelerationTermInfo(start_index, end_index, static_cast<int>(dof)));
+    else
+      term_infos.costs.push_back(createSmoothAccelerationTermInfo(start_index, end_index, acceleration_coeff));
+  }
+
+  if (smooth_jerks)
+  {
+    if (jerk_coeff.size() == 0)
+      term_infos.costs.push_back(createSmoothJerkTermInfo(start_index, end_index, static_cast<int>(dof)));
+    else
+      term_infos.costs.push_back(createSmoothJerkTermInfo(start_index, end_index, jerk_coeff));
+  }
+
+  if (avoid_singularity)
+    term_infos.costs.push_back(createAvoidSingularityTermInfo(
+        start_index, end_index, composite_manip_info.tcp_frame, avoid_singularity_coeff));
+
+  return term_infos;
+}
+
+double TrajOptCustomCompositeProfile::computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const
+{
+  // Calculate longest valid segment length
+  double extent = (joint_limits.col(1) - joint_limits.col(0)).norm();
+  if (longest_valid_segment_fraction > 0 && longest_valid_segment_length > 0)
+    return std::min(longest_valid_segment_fraction * extent, longest_valid_segment_length);
+
+  if (longest_valid_segment_fraction > 0)
+    return longest_valid_segment_fraction * extent;
+
+  if (longest_valid_segment_length > 0)
+    return longest_valid_segment_length;
+
+  return LONGEST_VALID_SEGMENT_FRACTION_DEFAULT * extent;
+}
+
+template <class Archive>
+void TrajOptCustomCompositeProfile::serialize(Archive& ar, const unsigned int /*version*/)
+{
+  ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TrajOptCompositeProfile);
+  ar& BOOST_SERIALIZATION_NVP(contact_test_type);
+  ar& BOOST_SERIALIZATION_NVP(collision_cost_config);
+  ar& BOOST_SERIALIZATION_NVP(collision_constraint_config);
+  ar& BOOST_SERIALIZATION_NVP(smooth_velocities);
+  ar& BOOST_SERIALIZATION_NVP(velocity_coeff);
+  ar& BOOST_SERIALIZATION_NVP(smooth_accelerations);
+  ar& BOOST_SERIALIZATION_NVP(acceleration_coeff);
+  ar& BOOST_SERIALIZATION_NVP(smooth_jerks);
+  ar& BOOST_SERIALIZATION_NVP(jerk_coeff);
+  ar& BOOST_SERIALIZATION_NVP(avoid_singularity);
+  ar& BOOST_SERIALIZATION_NVP(avoid_singularity_coeff);
+  ar& BOOST_SERIALIZATION_NVP(longest_valid_segment_fraction);
+  ar& BOOST_SERIALIZATION_NVP(longest_valid_segment_length);
+  ar& BOOST_SERIALIZATION_NVP(special_collision_cost);
+  ar& BOOST_SERIALIZATION_NVP(special_collision_constraint);
+}
+
+}  // namespace tesseract_planning
+
+#include <tesseract_common/serialization.h>
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptCustomCompositeProfile)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptCustomCompositeProfile)

--- a/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
+++ b/snp_motion_planning/src/trajopt_custom_composite_profile.cpp
@@ -26,141 +26,29 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <trajopt/problem_description.hpp>
-#include <boost/algorithm/string.hpp>
+#include <trajopt_ifopt/variable_sets/joint_position_variable.h>
+#include <trajopt_common/collision_types.h>
+#include <trajopt_common/utils.hpp>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include "trajopt_ifopt_custom_composite_profile.h"
-#include <tesseract_motion_planners/trajopt/trajopt_utils.h>
-#include <tesseract_motion_planners/core/utils.h>
+#include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_utils.h>
 
-#include <tesseract_command_language/poly/instruction_poly.h>
-#include <tesseract_command_language/poly/move_instruction_poly.h>
-#include <tesseract_command_language/cartesian_waypoint.h>
-#include <tesseract_command_language/joint_waypoint.h>
-
-#include <tesseract_common/eigen_serialization.h>
 #include <tesseract_common/manipulator_info.h>
-#include <tesseract_kinematics/core/joint_group.h>
-#include <tesseract_environment/environment.h>
-#include <trajopt_common/utils.hpp>
+#include <tesseract_common/eigen_serialization.h>
+#include <tesseract_collision/core/serialization.h>
 
-static const double LONGEST_VALID_SEGMENT_FRACTION_DEFAULT = 0.01;
 
 namespace tesseract_planning
 {
-TrajOptTermInfos
-TrajOptIfoptCustomCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
-                                           const std::shared_ptr<const tesseract_environment::Environment>& env,
-                                           const std::vector<int>& fixed_indices, int start_index, int end_index) const
-{
-  // -------- Construct the problem ------------
-  // -------------------------------------------
-  TrajOptTermInfos term_infos;
-  tesseract_kinematics::JointGroup::ConstPtr joint_group = env->getJointGroup(composite_manip_info.manipulator);
-  const Eigen::Index dof = joint_group->numJoints();
-  const Eigen::MatrixX2d joint_limits = joint_group->getLimits().joint_limits;
-  const double lvs_length = computeLongestValidSegmentLength(joint_limits);
-
-  if (collision_constraint_config.enabled)
-  {
-    trajopt::TermInfo::Ptr ti =
-        createCollisionTermInfo(start_index, end_index, collision_constraint_config.safety_margin,
-                                collision_constraint_config.safety_margin_buffer, collision_constraint_config.type,
-                                collision_constraint_config.use_weighted_sum, collision_constraint_config.coeff,
-                                contact_test_type, lvs_length, trajopt::TermType::TT_CNT);
-
-    // Update the term info with the (possibly) new start and end state indices for which to apply this cost
-    std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
-    if (special_collision_constraint)
-    {
-      for (auto& info : ct->info)
-      {
-        info = special_collision_constraint;
-      }
-    }
-    ct->fixed_steps = fixed_indices;
-
-    term_infos.constraints.push_back(ct);
-  }
-
-  if (collision_cost_config.enabled)
-  {
-    // Create a default collision term info
-    trajopt::TermInfo::Ptr ti = createCollisionTermInfo(
-        start_index, end_index, collision_cost_config.safety_margin, collision_cost_config.safety_margin_buffer,
-        collision_cost_config.type, collision_cost_config.use_weighted_sum, collision_cost_config.coeff,
-        contact_test_type, lvs_length, trajopt::TermType::TT_COST);
-
-    // Update the term info with the (possibly) new start and end state indices for which to apply this cost
-    std::shared_ptr<trajopt::CollisionTermInfo> ct = std::static_pointer_cast<trajopt::CollisionTermInfo>(ti);
-    if (special_collision_cost)
-    {
-      for (auto& info : ct->info)
-      {
-        info = special_collision_cost;
-      }
-    }
-    ct->fixed_steps = fixed_indices;
-
-    term_infos.costs.push_back(ct);
-  }
-
-  if (smooth_velocities)
-  {
-    if (velocity_coeff.size() == 0)
-      term_infos.costs.push_back(createSmoothVelocityTermInfo(start_index, end_index, static_cast<int>(dof)));
-    else
-      term_infos.costs.push_back(createSmoothVelocityTermInfo(start_index, end_index, velocity_coeff));
-  }
-
-  if (smooth_accelerations)
-  {
-    if (acceleration_coeff.size() == 0)
-      term_infos.costs.push_back(createSmoothAccelerationTermInfo(start_index, end_index, static_cast<int>(dof)));
-    else
-      term_infos.costs.push_back(createSmoothAccelerationTermInfo(start_index, end_index, acceleration_coeff));
-  }
-
-  if (smooth_jerks)
-  {
-    if (jerk_coeff.size() == 0)
-      term_infos.costs.push_back(createSmoothJerkTermInfo(start_index, end_index, static_cast<int>(dof)));
-    else
-      term_infos.costs.push_back(createSmoothJerkTermInfo(start_index, end_index, jerk_coeff));
-  }
-
-  if (avoid_singularity)
-    term_infos.costs.push_back(createAvoidSingularityTermInfo(start_index, end_index, composite_manip_info.tcp_frame,
-                                                              avoid_singularity_coeff));
-
-  return term_infos;
-}
-
-double TrajOptIfoptCustomCompositeProfile::computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const
-{
-  // Calculate longest valid segment length
-  double extent = (joint_limits.col(1) - joint_limits.col(0)).norm();
-  if (longest_valid_segment_fraction > 0 && longest_valid_segment_length > 0)
-    return std::min(longest_valid_segment_fraction * extent, longest_valid_segment_length);
-
-  if (longest_valid_segment_fraction > 0)
-    return longest_valid_segment_fraction * extent;
-
-  if (longest_valid_segment_length > 0)
-    return longest_valid_segment_length;
-
-  return LONGEST_VALID_SEGMENT_FRACTION_DEFAULT * extent;
-}
 
 template <class Archive>
 void TrajOptIfoptCustomCompositeProfile::serialize(Archive& ar, const unsigned int /*version*/)
 {
-  ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TrajOptCompositeProfile);
-  ar& BOOST_SERIALIZATION_NVP(contact_test_type);
+  ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TrajOptIfoptDefaultCompositeProfile);
   ar& BOOST_SERIALIZATION_NVP(collision_cost_config);
   ar& BOOST_SERIALIZATION_NVP(collision_constraint_config);
   ar& BOOST_SERIALIZATION_NVP(smooth_velocities);
@@ -169,12 +57,11 @@ void TrajOptIfoptCustomCompositeProfile::serialize(Archive& ar, const unsigned i
   ar& BOOST_SERIALIZATION_NVP(acceleration_coeff);
   ar& BOOST_SERIALIZATION_NVP(smooth_jerks);
   ar& BOOST_SERIALIZATION_NVP(jerk_coeff);
-  ar& BOOST_SERIALIZATION_NVP(avoid_singularity);
-  ar& BOOST_SERIALIZATION_NVP(avoid_singularity_coeff);
   ar& BOOST_SERIALIZATION_NVP(longest_valid_segment_fraction);
   ar& BOOST_SERIALIZATION_NVP(longest_valid_segment_length);
-  ar& BOOST_SERIALIZATION_NVP(special_collision_cost);
   ar& BOOST_SERIALIZATION_NVP(special_collision_constraint);
+  ar& BOOST_SERIALIZATION_NVP(special_collision_cost);
+  ar& BOOST_SERIALIZATION_NVP(contact_test_type);
 }
 
 }  // namespace tesseract_planning

--- a/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.cpp
+++ b/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.cpp
@@ -41,7 +41,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_common/eigen_serialization.h>
 #include <tesseract_collision/core/serialization.h>
 
-
 namespace tesseract_planning
 {
 

--- a/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
+++ b/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
@@ -99,9 +99,7 @@ public:
 
   TrajOptTermInfos create(const tesseract_common::ManipulatorInfo& composite_manip_info,
                           const std::shared_ptr<const tesseract_environment::Environment>& env,
-                          const std::vector<int>& fixed_indices,
-                          int start_index,
-                          int end_index) const override;
+                          const std::vector<int>& fixed_indices, int start_index, int end_index) const override;
 
 protected:
   double computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const;

--- a/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
+++ b/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
@@ -1,0 +1,117 @@
+/**
+ * @file trajopt_default_composite_profile.h
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @date June 18, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TESSERACT_MOTION_PLANNERS_TRAJOPT_CUSTOM_COMPOSITE_PROFILE_H
+#define TESSERACT_MOTION_PLANNERS_TRAJOPT_CUSTOM_COMPOSITE_PROFILE_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <vector>
+#include <memory>
+#include <Eigen/Core>
+#include <trajopt/fwd.hpp>
+#include <trajopt_common/fwd.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_motion_planners/trajopt/trajopt_collision_config.h>
+#include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
+
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+
+namespace tesseract_planning
+{
+class TrajOptIfoptCustomCompositeProfile : public TrajOptCompositeProfile
+{
+public:
+  using Ptr = std::shared_ptr<TrajOptIfoptCustomCompositeProfile>;
+  using ConstPtr = std::shared_ptr<const TrajOptIfoptCustomCompositeProfile>;
+
+  TrajOptIfoptCustomCompositeProfile() = default;
+
+  /** @brief The type of contact test to perform: FIRST, CLOSEST, ALL */
+  tesseract_collision::ContactTestType contact_test_type{ tesseract_collision::ContactTestType::ALL };
+  /** @brief Configuration info for collisions that are modeled as costs */
+  CollisionCostConfig collision_cost_config;
+  /** @brief Configuration info for collisions that are modeled as constraints */
+  CollisionConstraintConfig collision_constraint_config;
+  /** @brief If true, a joint velocity cost with a target of 0 will be applied for all timesteps Default: true*/
+  bool smooth_velocities = true;
+  /** @brief This default to all ones, but allows you to weight different joints */
+  Eigen::VectorXd velocity_coeff{};
+  /** @brief If true, a joint acceleration cost with a target of 0 will be applied for all timesteps Default: false*/
+  bool smooth_accelerations = true;
+  /** @brief This default to all ones, but allows you to weight different joints */
+  Eigen::VectorXd acceleration_coeff{};
+  /** @brief If true, a joint jerk cost with a target of 0 will be applied for all timesteps Default: false*/
+  bool smooth_jerks = true;
+  /** @brief This default to all ones, but allows you to weight different joints */
+  Eigen::VectorXd jerk_coeff{};
+  /** @brief If true, applies a cost to avoid kinematic singularities */
+  bool avoid_singularity = false;
+  /** @brief Optimization weight associated with kinematic singularity avoidance */
+  double avoid_singularity_coeff = 5.0;
+
+  /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
+   * to be considered valid in post checking of trajectory returned by trajopt.
+   *
+   * The resolution is equal to longest_valid_segment_fraction * state_space.getMaximumExtent()
+   *
+   * Note: The planner takes the conservative of either longest_valid_segment_fraction or longest_valid_segment_length.
+   */
+  double longest_valid_segment_fraction = 0.01;  // 1%
+
+  /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
+   * to be considered valid. If norm(state1 - state0) > longest_valid_segment_length.
+   *
+   * Note: This gets converted to longest_valid_segment_fraction.
+   *       longest_valid_segment_fraction = longest_valid_segment_length / state_space.getMaximumExtent()
+   */
+  double longest_valid_segment_length = 0.1;
+
+  /**@brief Special link collision cost distances */
+  std::shared_ptr<trajopt_common::SafetyMarginData> special_collision_cost{ nullptr };
+  /**@brief Special link collision constraint distances */
+  std::shared_ptr<trajopt_common::SafetyMarginData> special_collision_constraint{ nullptr };
+
+  TrajOptTermInfos create(const tesseract_common::ManipulatorInfo& composite_manip_info,
+                          const std::shared_ptr<const tesseract_environment::Environment>& env,
+                          const std::vector<int>& fixed_indices,
+                          int start_index,
+                          int end_index) const override;
+
+protected:
+  double computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const;
+
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive&, const unsigned int);  // NOLINT
+};
+}  // namespace tesseract_planning
+
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::TrajOptIfoptCustomCompositeProfile)
+
+#endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_DEFAULT_COMPOSITE_PROFILE_H

--- a/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
+++ b/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
@@ -52,7 +52,7 @@ public:
   tesseract_collision::ContactTestType contact_test_type{ tesseract_collision::ContactTestType::ALL };
   CollisionCostConfig collision_cost_config;
   CollisionConstraintConfig collision_constraint_config;
-  
+
   /**@brief Special link collision cost distances */
   std::shared_ptr<trajopt_common::SafetyMarginData> special_collision_cost{ nullptr };
   /**@brief Special link collision constraint distances */

--- a/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
+++ b/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
@@ -37,73 +37,28 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt/trajopt_collision_config.h>
-#include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
+#include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_composite_profile.h>
 
 #include <tesseract_collision/core/fwd.h>
 #include <tesseract_collision/core/types.h>
 
 namespace tesseract_planning
 {
-class TrajOptIfoptCustomCompositeProfile : public TrajOptCompositeProfile
+class TrajOptIfoptCustomCompositeProfile : public TrajOptIfoptDefaultCompositeProfile
 {
 public:
-  using Ptr = std::shared_ptr<TrajOptIfoptCustomCompositeProfile>;
-  using ConstPtr = std::shared_ptr<const TrajOptIfoptCustomCompositeProfile>;
-
   TrajOptIfoptCustomCompositeProfile() = default;
 
-  /** @brief The type of contact test to perform: FIRST, CLOSEST, ALL */
   tesseract_collision::ContactTestType contact_test_type{ tesseract_collision::ContactTestType::ALL };
-  /** @brief Configuration info for collisions that are modeled as costs */
   CollisionCostConfig collision_cost_config;
-  /** @brief Configuration info for collisions that are modeled as constraints */
   CollisionConstraintConfig collision_constraint_config;
-  /** @brief If true, a joint velocity cost with a target of 0 will be applied for all timesteps Default: true*/
-  bool smooth_velocities = true;
-  /** @brief This default to all ones, but allows you to weight different joints */
-  Eigen::VectorXd velocity_coeff{};
-  /** @brief If true, a joint acceleration cost with a target of 0 will be applied for all timesteps Default: false*/
-  bool smooth_accelerations = true;
-  /** @brief This default to all ones, but allows you to weight different joints */
-  Eigen::VectorXd acceleration_coeff{};
-  /** @brief If true, a joint jerk cost with a target of 0 will be applied for all timesteps Default: false*/
-  bool smooth_jerks = true;
-  /** @brief This default to all ones, but allows you to weight different joints */
-  Eigen::VectorXd jerk_coeff{};
-  /** @brief If true, applies a cost to avoid kinematic singularities */
-  bool avoid_singularity = false;
-  /** @brief Optimization weight associated with kinematic singularity avoidance */
-  double avoid_singularity_coeff = 5.0;
-
-  /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
-   * to be considered valid in post checking of trajectory returned by trajopt.
-   *
-   * The resolution is equal to longest_valid_segment_fraction * state_space.getMaximumExtent()
-   *
-   * Note: The planner takes the conservative of either longest_valid_segment_fraction or longest_valid_segment_length.
-   */
-  double longest_valid_segment_fraction = 0.01;  // 1%
-
-  /** @brief Set the resolution at which state validity needs to be verified in order for a motion between two states
-   * to be considered valid. If norm(state1 - state0) > longest_valid_segment_length.
-   *
-   * Note: This gets converted to longest_valid_segment_fraction.
-   *       longest_valid_segment_fraction = longest_valid_segment_length / state_space.getMaximumExtent()
-   */
-  double longest_valid_segment_length = 0.1;
-
+  
   /**@brief Special link collision cost distances */
   std::shared_ptr<trajopt_common::SafetyMarginData> special_collision_cost{ nullptr };
   /**@brief Special link collision constraint distances */
   std::shared_ptr<trajopt_common::SafetyMarginData> special_collision_constraint{ nullptr };
 
-  TrajOptTermInfos create(const tesseract_common::ManipulatorInfo& composite_manip_info,
-                          const std::shared_ptr<const tesseract_environment::Environment>& env,
-                          const std::vector<int>& fixed_indices, int start_index, int end_index) const override;
-
 protected:
-  double computeLongestValidSegmentLength(const Eigen::MatrixX2d& joint_limits) const;
-
   friend class boost::serialization::access;
   template <class Archive>
   void serialize(Archive&, const unsigned int);  // NOLINT

--- a/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
+++ b/snp_motion_planning/src/trajopt_ifopt_custom_composite_profile.h
@@ -49,6 +49,9 @@ class TrajOptIfoptCustomCompositeProfile : public TrajOptIfoptDefaultCompositePr
 public:
   TrajOptIfoptCustomCompositeProfile() = default;
 
+  /* The costs were added from the TrajOptDefaultCompositeProfile. To run the scan_n_plan workshop with
+   the default parameters they have used, these parameters are needed. They can be removed if it is not used.
+  */
   tesseract_collision::ContactTestType contact_test_type{ tesseract_collision::ContactTestType::ALL };
   CollisionCostConfig collision_cost_config;
   CollisionConstraintConfig collision_constraint_config;


### PR DESCRIPTION
## Description of the PR

The goal of this PR is to integrate the custom profiles for trajopt into our existing software stack to validate that it is added and can be used in motion planning. [NXT03-539](https://samxl.atlassian.net/browse/NXT03-539)

This create a class that has a custom profile that inherits from trajopt_ifopt_profile.
This is added the profile profile dictionary into the planning server. Then this profile is used to create trajectories for the toolpath/ configs provided. 

## Motivation and Context
This acts as a starting point for adding custom constraints including stiffness in the future. This PR allows us to add customs constraints with ifopt library instead of termInfoObject which doesn't allow for much customization. 

## Changes

- Add custom ifopt profile.
- Import profile into SNP profile dictionary.
- Update cmakelist to include required dependencies. 

## Testing Instruction

Run any the planning server and the client with instructions from [here](https://gitlab.tudelft.nl/samxl/projects/23ind02_nxtgen03/mobile_ndt_inspection/nxtgen_mni_motion_planning/-/blob/main/README.md?ref_type=heads).