### PR TITLE
Make it possible to do freespace planning from the current joint pose

### DIFF
--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -726,7 +726,18 @@ private:
 
       tesseract_planning::CompositeInstruction freespace_program(PROFILE, manip_info);
 
-      tesseract_planning::JointWaypoint wp1 = rosJointStateToJointWaypoint(req->js1);
+      tesseract_planning::JointWaypoint wp1;
+      if (req->js1.name.size() > 0)
+      {
+        // If we got a starting joint states message
+        wp1 = rosJointStateToJointWaypoint(req->js1);
+      }
+      else
+      {
+        // Otherwise plan from the current state
+        const std::vector<std::string> joint_names = env_->getJointGroup(manip_info.manipulator)->getJointNames();
+        wp1 = tesseract_planning::JointWaypoint{ joint_names, env_->getCurrentJointValues(joint_names) };
+      }
       tesseract_planning::JointWaypoint wp2 = rosJointStateToJointWaypoint(req->js2);
 
       // Define a freespace move to the first waypoint


### PR DESCRIPTION
Currently, the freespace planning interface requires two joint states, a start and an end state:

https://github.com/sam-xl/scan_n_plan_workshop/blob/5d9688f7ec0f360976edf8f27a1aeb2d8c95348d/snp_msgs/srv/GenerateFreespaceMotionPlan.srv#L1-L17

In many cases, planning should start at the current state, which is known to the planning server already.

This PR allows planning from the current state, if the incoming start joint state contains no joint names (i.e. is empty). If a start joint state **is** given then it is used. This allows us to keep using the existing interfaces in a backwards-compatible way.