### PR TITLE
Add option to publish tf through the environment monitor

### DIFF
--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -4,6 +4,7 @@
   <arg name="robot_description"/>
   <arg name="robot_description_semantic"/>
   <arg name="verbose" default="False"/>
+  <arg name="publish_tf" default="false"/>
   <!-- Add empty string to empty list so parameter exceptions aren't thrown. See https://github.com/ros2/rclcpp/issues/1955 -->
   <arg name="scan_disabled_contact_links" default="['']" description="List of links that should be allowed to collide with the scan (e.g., link to which the scan is attached) "/>
   <arg name="scan_reduced_contact_links" default="['']" description="List of links whose minimum acceptable contact distance to the scan should be set to 0.0 (e.g., the TCP link)"/>
@@ -29,7 +30,6 @@
   <arg name="tcp_max_speed" default="0.25"/>
   <arg name="cartesian_tolerance" default="[0.01, 0.01, 0.01, 0.05, 0.05, 6.28]"/>
   <arg name="cartesian_coefficient" default="[2.5, 2.5, 2.5, 2.5, 2.5, 0.0]"/>
-  <arg name="publish_tf" default="false"/>
 
   <node pkg="snp_motion_planning" exec="snp_motion_planning_node" output="screen">
     <!-- General -->
@@ -61,9 +61,5 @@
     <param name="cartesian_tolerance" value="$(var cartesian_tolerance)"/>
     <param name="cartesian_coefficient" value="$(var cartesian_coefficient)"/>
     <param name="publish_tf" value="$(var publish_tf)"/>
-    
-    <!-- Dynamic TF is handled by the robot_state_publisher. Avoid conflicts
-         by remapping the topic. -->
-    <remap from="/tf" to="/tf_tesseract"/>
   </node>
 </launch>

--- a/snp_motion_planning/launch/planning_server.launch.xml
+++ b/snp_motion_planning/launch/planning_server.launch.xml
@@ -29,6 +29,7 @@
   <arg name="tcp_max_speed" default="0.25"/>
   <arg name="cartesian_tolerance" default="[0.01, 0.01, 0.01, 0.05, 0.05, 6.28]"/>
   <arg name="cartesian_coefficient" default="[2.5, 2.5, 2.5, 2.5, 2.5, 0.0]"/>
+  <arg name="publish_tf" default="false"/>
 
   <node pkg="snp_motion_planning" exec="snp_motion_planning_node" output="screen">
     <!-- General -->
@@ -59,5 +60,10 @@
     <param name="tcp_max_speed" value = "$(var tcp_max_speed)"/>
     <param name="cartesian_tolerance" value="$(var cartesian_tolerance)"/>
     <param name="cartesian_coefficient" value="$(var cartesian_coefficient)"/>
+    <param name="publish_tf" value="$(var publish_tf)"/>
+    
+    <!-- Dynamic TF is handled by the robot_state_publisher. Avoid conflicts
+         by remapping the topic. -->
+    <remap from="/tf" to="/tf_tesseract"/>
   </node>
 </launch>

--- a/snp_motion_planning/src/planning_server.cpp
+++ b/snp_motion_planning/src/planning_server.cpp
@@ -62,6 +62,7 @@ static const std::string SCAN_LINK_NAME = "scan";
 static const std::string SCAN_DISABLED_CONTACT_LINKS = "scan_disabled_contact_links";
 static const std::string SCAN_REDUCED_CONTACT_LINKS_PARAM = "scan_reduced_contact_links";
 static const std::string VERBOSE_PARAM = "verbose";
+static const std::string PUBLISH_TF_PARAM = "publish_tf";
 //   Scan link
 static const std::string COLLISION_OBJECT_TYPE_PARAM = "collision_object_type";
 static const std::string OCTREE_RESOLUTION_PARAM = "octree_resolution";
@@ -258,6 +259,7 @@ public:
     node_->declare_parameter<double>(OCTREE_RESOLUTION_PARAM, 0.010);
     node_->declare_parameter<int>(MAX_CONVEX_HULLS, 64);
     node_->declare_parameter(COLLISION_OBJECT_TYPE_PARAM, "convex_mesh");
+    node_->declare_parameter(PUBLISH_TF_PARAM, false);
 
     // Profiles
     node_->declare_parameter(MAX_TRANS_VEL_PARAM, 0.05);
@@ -296,7 +298,7 @@ public:
     tesseract_monitor_ =
         std::make_shared<tesseract_monitoring::ROSEnvironmentMonitor>(node_, env_, TESSERACT_MONITOR_NAMESPACE);
     tesseract_monitor_->setEnvironmentPublishingFrequency(30.0);
-    tesseract_monitor_->startPublishingEnvironment();
+    tesseract_monitor_->startPublishingEnvironment(get<bool>(node_, PUBLISH_TF_PARAM));
     tesseract_monitor_->startStateMonitor(tesseract_monitoring::DEFAULT_JOINT_STATES_TOPIC, false);
 
     // Advertise the ROS2 service


### PR DESCRIPTION
When changing the Tesseract scene, it is helpful to see it reflected in the visualization. This PR adds an option to make the Tesseract ROS Environment Monitor publish TF frames. Note that we assume dynamic TFs (related to robot motions) are handled by the `robot_state_publisher`. To avoid conflicts, we only use the frames published on `tf_static`.